### PR TITLE
Retain logic instance in UnioStream

### DIFF
--- a/Example/UnioSample/GitHubSearchLogicStream.swift
+++ b/Example/UnioSample/GitHubSearchLogicStream.swift
@@ -47,7 +47,6 @@ extension GitHubSearchLogicStream {
 
         let searchAPIStream: GitHubSearchAPIStreamType
         let scheduler: SchedulerType
-        let disposeBag = DisposeBag()
     }
 
     struct Logic: LogicType {
@@ -55,6 +54,8 @@ extension GitHubSearchLogicStream {
         typealias Output = GitHubSearchLogicStream.Output
         typealias State = GitHubSearchLogicStream.State
         typealias Extra = GitHubSearchLogicStream.Extra
+
+        let disposeBag = DisposeBag()
     }
 }
 
@@ -64,7 +65,6 @@ extension GitHubSearchLogicStream.Logic {
 
         let state = dependency.state
         let extra = dependency.extra
-        let disposeBag = extra.disposeBag
         let searchAPIStream = extra.searchAPIStream
 
         searchAPIStream.output

--- a/Example/UnioSample/GitHubSearchViewStream.swift
+++ b/Example/UnioSample/GitHubSearchViewStream.swift
@@ -51,6 +51,8 @@ extension GitHubSearchViewStream {
         typealias Output = GitHubSearchViewStream.Output
         typealias State = GitHubSearchViewStream.State
         typealias Extra = GitHubSearchViewStream.Extra
+
+        let disposeBag = DisposeBag()
     }
 }
 
@@ -58,7 +60,6 @@ extension GitHubSearchViewStream.Logic {
 
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
 
-        let disposeBag = dependency.extra.disposeBag
         let logicStream = dependency.extra.logicStream
 
         dependency.inputObservable(for: \.searchText)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ The rule of Extra is having other dependencies of [UnioStream](#uniostream).
 ```swift
 struct Extra: ExtraType {
     let apiStream: GitHubSearchAPIStream()
-    let disposeBag = DisposeBag()
 }
 ```
 
@@ -144,6 +143,7 @@ struct Extra: ExtraType {
 The rule of Logic is generating [Output](#output) from Dependency<Input, State, Extra>.
 It generates [Output](#output) to call `func bind(from:)`.
 `func bind(from:)` is called once when [UnioStream](#uniostream) is initialized.
+If you want to use DisposeBags in `func bind(from:)`, define properties of DisposeBag in Logic.
 
 ```swift
 struct Logic: LogicType {
@@ -151,6 +151,8 @@ struct Logic: LogicType {
     typealias Output = GitHubSearchViewStream.Output
     typealias State = GitHubSearchViewStream.State
     typealias Extra = GitHubSearchViewStream.Extra
+
+    let disposeBag = DisposeBag()
 
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output
 }
@@ -169,7 +171,6 @@ Here is a exmaple of implementation.
 extension GitHubSearchViewStream.Logic {
 
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
-        let disposeBag = dependency.extra.disposeBag
         let apiStream = dependency.extra.apiStream
 
         dependency.inputObservable(for: \.searchText)
@@ -244,7 +245,6 @@ final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream.Logic>, Gi
 
     struct Extra: ExtraType {
         let apiStream: GitHubSearchAPIStream()
-        let disposeBag = DisposeBag()
     }
 
     struct Logic: LogicType {
@@ -252,13 +252,14 @@ final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream.Logic>, Gi
         typealias Output = GitHubSearchViewStream.Output
         typealias State = GitHubSearchViewStream.State
         typealias Extra = GitHubSearchViewStream.Extra
+
+        let disposeBag = DisposeBag()
     }
 }
 
 extension GitHubSearchViewStream.Logic {
 
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
-        let disposeBag = dependency.extra.disposeBag
         let apiStream = dependency.extra.apiStream
 
         dependency.inputObservable(for: \.searchText)

--- a/Tools/Mock UnioStream.xctemplate/Mock___FILEBASENAME___Stream.swift
+++ b/Tools/Mock UnioStream.xctemplate/Mock___FILEBASENAME___Stream.swift
@@ -1,8 +1,8 @@
 //___FILEHEADER___
 
-import Unio
-import RxSwift
 import RxCocoa
+import RxSwift
+import Unio
 
 final class Mock___VARIABLE_productName___Stream: ___VARIABLE_productName___StreamType {
 

--- a/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewController.swift
+++ b/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewController.swift
@@ -1,8 +1,8 @@
 //___FILEHEADER___
 
-import Unio
-import UIKit
 import RxSwift
+import UIKit
+import Unio
 
 final class ___VARIABLE_productName___ViewController: UIViewController {
 

--- a/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
+++ b/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
@@ -1,8 +1,8 @@
 //___FILEHEADER___
 
-import Unio
-import RxSwift
 import RxCocoa
+import RxSwift
+import Unio
 
 protocol ___VARIABLE_productName___ViewStreamType: AnyObject {
     var input: Relay<___VARIABLE_productName___ViewStream.Input> { get }
@@ -51,7 +51,6 @@ extension ___VARIABLE_productName___ViewStream {
 
     struct Extra: ExtraType {
 
-        let disposeBag = DisposeBag()
     }
 
     struct Logic: LogicType {
@@ -59,6 +58,8 @@ extension ___VARIABLE_productName___ViewStream {
         typealias Output = ___VARIABLE_productName___ViewStream.Output
         typealias State = ___VARIABLE_productName___ViewStream.State
         typealias Extra = ___VARIABLE_productName___ViewStream.Extra
+
+        let disposeBag = DisposeBag()
     }
 }
 
@@ -67,7 +68,6 @@ extension ___VARIABLE_productName___ViewStream.Logic {
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
 
         let state = dependency.state
-        let disposeBag = dependency.extra.disposeBag
 
         /*
          *  EXAMPLE:

--- a/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
+++ b/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
@@ -1,8 +1,8 @@
 //___FILEHEADER___
 
-import Unio
-import RxSwift
 import RxCocoa
+import RxSwift
+import Unio
 
 protocol ___VARIABLE_productName___StreamType: AnyObject {
     var input: Relay<___VARIABLE_productName___Stream.Input> { get }
@@ -51,7 +51,6 @@ extension ___VARIABLE_productName___Stream {
 
     struct Extra: ExtraType {
 
-        let disposeBag = DisposeBag()
     }
 
     struct Logic: LogicType {
@@ -59,6 +58,8 @@ extension ___VARIABLE_productName___Stream {
         typealias Output = ___VARIABLE_productName___Stream.Output
         typealias State = ___VARIABLE_productName___Stream.State
         typealias Extra = ___VARIABLE_productName___Stream.Extra
+
+        let disposeBag = DisposeBag()
     }
 }
 
@@ -67,7 +68,6 @@ extension ___VARIABLE_productName___Stream.Logic {
     func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
 
         let state = dependency.state
-        let disposeBag = dependency.extra.disposeBag
 
         /*
          *  EXAMPLE:

--- a/Unio.podspec
+++ b/Unio.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Unio"
-  s.version      = "0.2.0"
+  s.version      = "0.3.0"
   s.summary      = "KeyPath based Unidirectionarl Input / Output framework with RxSwift."
   s.homepage     = "https://github.com/cats-oss/Unio"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Unio/UnioStream.swift
+++ b/Unio/UnioStream.swift
@@ -14,7 +14,9 @@ open class UnioStream<Logic: LogicType> {
 
     private let state: StateType
     private let extra: ExtraType
+    private let logic: Logic
 
+    /// - note: initialize parameters are retained in UnioStream
     public init(input: Logic.Input, state: Logic.State, extra: Logic.Extra, logic: Logic) {
         let dependency = Dependency(input: input, state: state, extra: extra)
         let output = logic.bind(from: dependency)
@@ -22,5 +24,6 @@ open class UnioStream<Logic: LogicType> {
         self.output = Relay(output)
         self.state = state
         self.extra = extra
+        self.logic = logic
     }
 }


### PR DESCRIPTION
Below implementation causes circular retain, because extra has disposeBag used in closure but closure retained by disposeBag.

```swift
extension SomeStream {
    ...
    struct Extra {
        let disposeBag = DisposeBag()
    }

    struct Logic {
        ...
        func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
            
            dependency.inputObservable(...)
                .subscribe(onNext: { _ in
                    dependency.extra
                })
                .disposed(by: dependency.extra.disposeBag)
            ....
        }
    }
}
```

To avoid above case, let us define a property of DisposeBag in Logic.
Logic is retained in UnioStream, therefore lifecycle of DisposeBag becomes same as UnioStream.

```swift
extension SomeStream {
    ...

    struct Logic {
        let disposeBag = DisposeBag()

        ...
        func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
            
            dependency.inputObservable(...)
                .subscribe(onNext: { _ in
                    dependency.extra
                })
                .disposed(by: disposeBag)
            ....
        }
    }
}
```