### PR TITLE
Add SwiftPM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: objective-c
 os: osx
 osx_image: xcode11
+env:
+  - CI_USE_SWIFTPM=true
+  - CI_USE_SWIFTPM=false
 before_install:
   - gem install xcpretty
-  - carthage update --no-use-binaries --platform ios
+  - |
+    if ! $CI_USE_SWIFTPM ; then
+      carthage update --no-use-binaries --platform ios
+    fi
 before_script:
   - set -o pipefail
-script:
-  - xcodebuild test -project ./Unio.xcodeproj -scheme Unio -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.2,name=iPhone 8' | xcpretty -c
+script: |
+  PROJECT_ARG=
+  if $CI_USE_SWIFTPM ; then
+    rm -rf *.xcodeproj
+  else
+    PROJECT_ARG="-project ./Unio.xcodeproj"
+  fi
+  xcodebuild test $PROJECT_ARG -scheme Unio -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.2,name=iPhone 8' | xcpretty -c
 notifications:
   email: false

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Unio",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "Unio",
+                 targets: ["Unio"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0")
+    ],
+    targets: [
+        .target(name: "Unio",
+                dependencies: ["RxSwift", "RxRelay"],
+                path: "Unio"),
+        .testTarget(name: "UnioTests",
+                    dependencies: ["Unio", "RxCocoa"],
+                    path: "UnioTests"),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
Added Package.swift to allow use from Xcode 11's SwiftPM integration.
.travis.yml is also fixed to check if tests pass with both .xcodeproj and Package.swift.