### PR TITLE
Improve LogicType implementation

### DIFF
--- a/Documentation/Unio0_6_0MigrationGuide.md
+++ b/Documentation/Unio0_6_0MigrationGuide.md
@@ -1,0 +1,15 @@
+# Unio 0.6.0 Migration Guide
+
+Unio 0.6.0 introduces some breaking changes.
+
+## Classes
+
+- [RENAME] `UnioStream<Logic>` -> `PrimitiveStream<Logic>`
+
+## Methods
+
+- [REPLACE] `LogicType func bind(from:)` -> `LogicType static func bind(from:disposeBag:)`
+
+## Typealias
+
+- [ADD] `typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType`

--- a/Example/UnioSample/GitHubSearchAPIStream.swift
+++ b/Example/UnioSample/GitHubSearchAPIStream.swift
@@ -17,7 +17,7 @@ protocol GitHubSearchAPIStreamType: AnyObject {
 
 final class GitHubSearchAPIStream: UnioStream<GitHubSearchAPIStream>, GitHubSearchAPIStreamType {
 
-    init(extra: Extra = .init()) {
+    init(extra: Extra = .init(session: .shared)) {
         super.init(input: Input(),
                    state: State(),
                    extra: extra)
@@ -25,7 +25,6 @@ final class GitHubSearchAPIStream: UnioStream<GitHubSearchAPIStream>, GitHubSear
 }
 
 extension GitHubSearchAPIStream {
-    typealias State = NoState
 
     struct Input: InputType {
 
@@ -40,10 +39,10 @@ extension GitHubSearchAPIStream {
 
     struct Extra: ExtraType {
 
-        let session = URLSession.shared
+        let session: URLSession
     }
 
-    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
+    static func bind(from dependency: Dependency<Input, NoState, Extra>, disposeBag: DisposeBag) -> Output {
 
         let session = dependency.extra.session
 

--- a/Example/UnioSample/GitHubSearchAPIStream.swift
+++ b/Example/UnioSample/GitHubSearchAPIStream.swift
@@ -15,13 +15,12 @@ protocol GitHubSearchAPIStreamType: AnyObject {
     var output: OutputWrapper<GitHubSearchAPIStream.Output> { get }
 }
 
-final class GitHubSearchAPIStream: UnioStream<GitHubSearchAPIStream.Logic>, GitHubSearchAPIStreamType {
+final class GitHubSearchAPIStream: UnioStream<GitHubSearchAPIStream>, GitHubSearchAPIStreamType {
 
     init(extra: Extra = .init()) {
         super.init(input: Input(),
                    state: State(),
-                   extra: extra,
-                   logic: Logic())
+                   extra: extra)
     }
 }
 
@@ -44,17 +43,7 @@ extension GitHubSearchAPIStream {
         let session = URLSession.shared
     }
 
-    struct Logic: LogicType {
-        typealias Input = GitHubSearchAPIStream.Input
-        typealias Output = GitHubSearchAPIStream.Output
-        typealias State = GitHubSearchAPIStream.State
-        typealias Extra = GitHubSearchAPIStream.Extra
-    }
-}
-
-extension GitHubSearchAPIStream.Logic {
-
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let session = dependency.extra.session
 

--- a/Example/UnioSample/GitHubSearchLogicStream.swift
+++ b/Example/UnioSample/GitHubSearchLogicStream.swift
@@ -15,13 +15,12 @@ protocol GitHubSearchLogicStreamType: AnyObject {
     var output: OutputWrapper<GitHubSearchLogicStream.Output> { get }
 }
 
-final class GitHubSearchLogicStream: UnioStream<GitHubSearchLogicStream.Logic>, GitHubSearchLogicStreamType {
+final class GitHubSearchLogicStream: UnioStream<GitHubSearchLogicStream>, GitHubSearchLogicStreamType {
 
     init(extra: Extra = .init(searchAPIStream: GitHubSearchAPIStream(), scheduler: ConcurrentMainScheduler.instance)) {
         super.init(input: Input(),
                    state: State(),
-                   extra: extra,
-                   logic: Logic())
+                   extra: extra)
     }
 }
 
@@ -49,19 +48,7 @@ extension GitHubSearchLogicStream {
         let scheduler: SchedulerType
     }
 
-    struct Logic: LogicType {
-        typealias Input = GitHubSearchLogicStream.Input
-        typealias Output = GitHubSearchLogicStream.Output
-        typealias State = GitHubSearchLogicStream.State
-        typealias Extra = GitHubSearchLogicStream.Extra
-
-        let disposeBag = DisposeBag()
-    }
-}
-
-extension GitHubSearchLogicStream.Logic {
-
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let state = dependency.state
         let extra = dependency.extra

--- a/Example/UnioSample/GitHubSearchViewStream.swift
+++ b/Example/UnioSample/GitHubSearchViewStream.swift
@@ -15,13 +15,12 @@ protocol GitHubSearchViewStreamType: AnyObject {
     var output: OutputWrapper<GitHubSearchViewStream.Output> { get }
 }
 
-final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream.Logic>, GitHubSearchViewStreamType {
+final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream>, GitHubSearchViewStreamType {
 
     init(extra: Extra = .init(logicStream: GitHubSearchLogicStream())) {
         super.init(input: Input(),
                    state: State(),
-                   extra: extra,
-                   logic: Logic())
+                   extra: extra)
     }
 }
 
@@ -46,19 +45,7 @@ extension GitHubSearchViewStream {
         let disposeBag = DisposeBag()
     }
 
-    struct Logic: LogicType {
-        typealias Input = GitHubSearchViewStream.Input
-        typealias Output = GitHubSearchViewStream.Output
-        typealias State = GitHubSearchViewStream.State
-        typealias Extra = GitHubSearchViewStream.Extra
-
-        let disposeBag = DisposeBag()
-    }
-}
-
-extension GitHubSearchViewStream.Logic {
-
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let logicStream = dependency.extra.logicStream
 

--- a/Example/UnioSample/GitHubSearchViewStream.swift
+++ b/Example/UnioSample/GitHubSearchViewStream.swift
@@ -26,8 +26,6 @@ final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream>, GitHubSe
 
 extension GitHubSearchViewStream {
 
-    typealias State = NoState
-
     struct Input: InputType {
 
         let searchText = PublishRelay<String?>()
@@ -42,10 +40,9 @@ extension GitHubSearchViewStream {
     struct Extra: ExtraType {
         
         let logicStream: GitHubSearchLogicStreamType
-        let disposeBag = DisposeBag()
     }
 
-    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
+    static func bind(from dependency: Dependency<Input, NoState, Extra>, disposeBag: DisposeBag) -> Output {
 
         let logicStream = dependency.extra.logicStream
 

--- a/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
+++ b/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
@@ -51,7 +51,6 @@ extension ___VARIABLE_productName___ViewStream {
 
     }
 
-
     static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let state = dependency.state

--- a/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
+++ b/Tools/Unio Components.xctemplate/Default/___FILEBASENAME___ViewStream.swift
@@ -9,13 +9,12 @@ protocol ___VARIABLE_productName___ViewStreamType: AnyObject {
     var output: OutputWrapper<___VARIABLE_productName___ViewStream.Output> { get }
 }
 
-final class ___VARIABLE_productName___ViewStream: UnioStream<___VARIABLE_productName___ViewStream.Logic>, ___VARIABLE_productName___ViewStreamType {
+final class ___VARIABLE_productName___ViewStream: UnioStream<___VARIABLE_productName___ViewStream>, ___VARIABLE_productName___ViewStreamType {
 
     init(extra: Extra = .init()) {
         super.init(input: Input(),
                    state: State(),
-                   extra: extra,
-                   logic: Logic())
+                   extra: extra)
     }
 }
 
@@ -52,19 +51,8 @@ extension ___VARIABLE_productName___ViewStream {
 
     }
 
-    struct Logic: LogicType {
-        typealias Input = ___VARIABLE_productName___ViewStream.Input
-        typealias Output = ___VARIABLE_productName___ViewStream.Output
-        typealias State = ___VARIABLE_productName___ViewStream.State
-        typealias Extra = ___VARIABLE_productName___ViewStream.Extra
 
-        let disposeBag = DisposeBag()
-    }
-}
-
-extension ___VARIABLE_productName___ViewStream.Logic {
-
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let state = dependency.state
 

--- a/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
+++ b/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
@@ -4,12 +4,12 @@ import RxCocoa
 import RxSwift
 import Unio
 
-protocol ___VARIABLE_productName___ViewStreamType: AnyObject {
-    var input: InputWrapper<___VARIABLE_productName___ViewStream.Input> { get }
-    var output: OutputWrapper<___VARIABLE_productName___ViewStream.Output> { get }
+protocol ___VARIABLE_productName___StreamType: AnyObject {
+    var input: InputWrapper<___VARIABLE_productName___Stream.Input> { get }
+    var output: OutputWrapper<___VARIABLE_productName___Stream.Output> { get }
 }
 
-final class ___VARIABLE_productName___ViewStream: UnioStream<___VARIABLE_productName___ViewStream>, ___VARIABLE_productName___ViewStreamType {
+final class ___VARIABLE_productName___Stream: UnioStream<___VARIABLE_productName___Stream>, ___VARIABLE_productName___StreamType {
 
     init(extra: Extra = .init()) {
         super.init(input: Input(),
@@ -18,7 +18,7 @@ final class ___VARIABLE_productName___ViewStream: UnioStream<___VARIABLE_product
     }
 }
 
-extension ___VARIABLE_productName___ViewStream {
+extension ___VARIABLE_productName___Stream {
 
     struct Input: InputType {
 
@@ -50,7 +50,6 @@ extension ___VARIABLE_productName___ViewStream {
     struct Extra: ExtraType {
 
     }
-
 
     static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 

--- a/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
+++ b/Tools/UnioStream.xctemplate/___FILEBASENAME___Stream.swift
@@ -4,22 +4,21 @@ import RxCocoa
 import RxSwift
 import Unio
 
-protocol ___VARIABLE_productName___StreamType: AnyObject {
-    var input: InputWrapper<___VARIABLE_productName___Stream.Input> { get }
-    var output: OutputWrapper<___VARIABLE_productName___Stream.Output> { get }
+protocol ___VARIABLE_productName___ViewStreamType: AnyObject {
+    var input: InputWrapper<___VARIABLE_productName___ViewStream.Input> { get }
+    var output: OutputWrapper<___VARIABLE_productName___ViewStream.Output> { get }
 }
 
-final class ___VARIABLE_productName___Stream: UnioStream<___VARIABLE_productName___Stream.Logic>, ___VARIABLE_productName___StreamType {
+final class ___VARIABLE_productName___ViewStream: UnioStream<___VARIABLE_productName___ViewStream>, ___VARIABLE_productName___ViewStreamType {
 
     init(extra: Extra = .init()) {
         super.init(input: Input(),
                    state: State(),
-                   extra: extra,
-                   logic: Logic())
+                   extra: extra)
     }
 }
 
-extension ___VARIABLE_productName___Stream {
+extension ___VARIABLE_productName___ViewStream {
 
     struct Input: InputType {
 
@@ -52,19 +51,8 @@ extension ___VARIABLE_productName___Stream {
 
     }
 
-    struct Logic: LogicType {
-        typealias Input = ___VARIABLE_productName___Stream.Input
-        typealias Output = ___VARIABLE_productName___Stream.Output
-        typealias State = ___VARIABLE_productName___Stream.State
-        typealias Extra = ___VARIABLE_productName___Stream.Extra
 
-        let disposeBag = DisposeBag()
-    }
-}
-
-extension ___VARIABLE_productName___Stream.Logic {
-
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output {
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
 
         let state = dependency.state
 

--- a/Unio.podspec
+++ b/Unio.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Unio"
-  s.version      = "0.5.0"
+  s.version      = "0.6.0"
   s.summary      = "KeyPath based Unidirectionarl Input / Output framework with RxSwift."
   s.homepage     = "https://github.com/cats-oss/Unio"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Unio/LogicType.swift
+++ b/Unio/LogicType.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 tv.abema. All rights reserved.
 //
 
+import RxSwift
+
 /// Represents definitions and implementations of UnioStream logic.
 public protocol LogicType {
     associatedtype Input: InputType
@@ -16,5 +18,5 @@ public protocol LogicType {
     /// Generates Output from Dependency.
     ///
     /// - note: This method called once when a linked UnioStream is initialized.
-    func bind(from dependency: Dependency<Input, State, Extra>) -> Output
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output
 }

--- a/Unio/UnioStream.swift
+++ b/Unio/UnioStream.swift
@@ -6,24 +6,27 @@
 //  Copyright © 2019 tv.abema. All rights reserved.
 //
 
+import RxSwift
+
+public typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType
+
 /// Makes possible to implement Unidirectional input / output stream.
-open class UnioStream<Logic: LogicType> {
+open class PrimitiveStream<Logic: LogicType> {
 
     public let input: InputWrapper<Logic.Input>
     public let output: OutputWrapper<Logic.Output>
 
     private let _state: Logic.State
     private let _extra: Logic.Extra
-    private let _logic: Logic
+    private let _disposeBag = DisposeBag()
 
     /// - note: initialize parameters are retained in UnioStream
-    public init(input: Logic.Input, state: Logic.State, extra: Logic.Extra, logic: Logic) {
+    public init(input: Logic.Input, state: Logic.State, extra: Logic.Extra) {
         let dependency = Dependency(input: input, state: state, extra: extra)
-        let output = logic.bind(from: dependency)
+        let output = Logic.bind(from: dependency, disposeBag: _disposeBag)
         self.input = InputWrapper(input)
         self.output = OutputWrapper(output)
         self._state = state
         self._extra = extra
-        self._logic = logic
     }
 }

--- a/Unio/UnioStream.swift
+++ b/Unio/UnioStream.swift
@@ -8,6 +8,24 @@
 
 import RxSwift
 
+/// Makes possible to implement Unidirectional input / output stream and be able to implement LogicType to  its self.
+///
+/// ```
+/// // Usage Example
+/// class GithubSearchStream: UnioStream<GithubSearchStream> {
+///     struct Input: InputType {}
+///
+///     struct Output: OutputType {}
+///
+///     struct State: StateType {}
+///
+///     struct Extra: ExtraType {}
+///
+///     static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
+///         return Output()
+///     }
+/// }
+/// ```
 public typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType
 
 /// Makes possible to implement Unidirectional input / output stream.


### PR DESCRIPTION
Be able to implement `LogicType` to UnioStream its self.

## Changes

- [RENAME] `UnioStream<Logic>` -> `PrimitiveStream<Logic>`
- [ADD] `typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType`
- [REPLACE] `LogicType func bind(from:)` -> `LogicType static func bind(from:disposeBag:)`

### Before

```swift
final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream.Logic> {

    init(extra: Extra = .init(logicStream: GitHubSearchLogicStream())) {
        super.init(input: Input(), state: State(), extra: extra, logic: Logic())
    }

    struct Input: InputType {
        let searchText = PublishRelay<String?>()
    }

    struct Output: OutputType {
        let repositories: Observable<[GitHub.Repository]>
        let errorMessage: Observable<String>
    }

    struct Extra: ExtraType {
        let logicStream: GitHubSearchLogicStreamType
    }

    struct Logic: LogicType {
        let disposeBag = DisposeBag()

        func bind(from dependency: Dependency<Input, NoState, Extra>) -> Output {
            let logicStream = dependency.extra.logicStream

            dependency.inputObservables.searchText
                .bind(to: logicStream.input.searchText)
                .disposed(by: disposeBag)
        
            return Output(repositories: logicStream.output.repositories,
                          errorMessage: logicStream.output.error.map { $0.localizedDescription })
    }
}
```

### After

```swift
final class GitHubSearchViewStream: UnioStream<GitHubSearchViewStream> {

    init(extra: Extra = .init(logicStream: GitHubSearchLogicStream())) {
        super.init(input: Input(), state: State(), extra: extra)
    }

    struct Input: InputType {
        let searchText = PublishRelay<String?>()
    }

    struct Output: OutputType {
        let repositories: Observable<[GitHub.Repository]>
        let errorMessage: Observable<String>
    }

    struct Extra: ExtraType {
        let logicStream: GitHubSearchLogicStreamType
    }

    static func bind(from dependency: Dependency<Input, NoState, Extra>, disposeBag: DisposeBag) -> Output {
        let logicStream = dependency.extra.logicStream

        dependency.inputObservables.searchText
            .bind(to: logicStream.input.searchText)
            .disposed(by: disposeBag)
        
        return Output(repositories: logicStream.output.repositories,
                      errorMessage: logicStream.output.error.map { $0.localizedDescription })
    }
}
```

## The reason why `bind` is static method

By this changes, LogicType is implemented in subclass of UnioStream.
If `bind` was instance method, be able to access properties in subclass of UnioStream.
It means there are possibilities to access side effects.
Dependencies in `bind` method is only possible to get from `Dependency<Input, State, Extra>` because makes easy to understand definitions.