### PR TITLE
Add UnioStreamType and AnyUnioStream

### DIFF
--- a/Unio.xcodeproj/project.pbxproj
+++ b/Unio.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		9DA555CB2241DE8400EC8CC3 /* BehaviorSubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555CA2241DE8400EC8CC3 /* BehaviorSubjectType.swift */; };
 		9DA555D32241FC0400EC8CC3 /* AcceptableRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */; };
 		9DA555D52241FC6600EC8CC3 /* ValueAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */; };
+		E9A6617E23839933007D4AEC /* AnyUnioStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */; };
+		E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6618123839952007D4AEC /* AnyUnioStream.swift */; };
 		ED6897C122B184EE00B04DA0 /* PrimitiveProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6897C022B184EE00B04DA0 /* PrimitiveProperty.swift */; };
 		ED74A63D2243C2EE00D4E99C /* PrimitivePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED74A63C2243C2EE00D4E99C /* PrimitivePropertyTests.swift */; };
 		ED74A6402243C3DB00D4E99C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */; };
@@ -83,6 +85,8 @@
 		9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptableRelay.swift; sourceTree = "<group>"; };
 		9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueAccessible.swift; sourceTree = "<group>"; };
 		9DA5623F2362DB760048F2B9 /* Unio.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Unio.xcconfig; sourceTree = "<group>"; };
+		E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStreamTests.swift; sourceTree = "<group>"; };
+		E9A6618123839952007D4AEC /* AnyUnioStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStream.swift; sourceTree = "<group>"; };
 		ED6897C022B184EE00B04DA0 /* PrimitiveProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimitiveProperty.swift; sourceTree = "<group>"; };
 		ED74A63C2243C2EE00D4E99C /* PrimitivePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimitivePropertyTests.swift; sourceTree = "<group>"; };
 		ED74A7372243D99D00D4E99C /* WrappersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappersTests.swift; sourceTree = "<group>"; };
@@ -137,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				9DA555C92241DE5F00EC8CC3 /* RxTypes */,
+				E9A6618123839952007D4AEC /* AnyUnioStream.swift */,
 				9D2E269C2240D1CA00C9EDF7 /* Dependency.swift */,
 				9D2E26972240D1CA00C9EDF7 /* ExtraType.swift */,
 				9D2E267D2240D18500C9EDF7 /* Info.plist */,
@@ -194,6 +199,7 @@
 		ED74A63E2243C2F200D4E99C /* TestCases */ = {
 			isa = PBXGroup;
 			children = (
+				E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */,
 				ED74A7392243E0CC00D4E99C /* DependencyTests.swift */,
 				ED74A63C2243C2EE00D4E99C /* PrimitivePropertyTests.swift */,
 				ED74A73B2243E43D00D4E99C /* UnioStreamTests.swift */,
@@ -326,6 +332,7 @@
 				9D2E269D2240D1CA00C9EDF7 /* PublishRelayType.swift in Sources */,
 				9D2E26A02240D1CA00C9EDF7 /* StateType.swift in Sources */,
 				9D2E26A42240D1CA00C9EDF7 /* UnioStream.swift in Sources */,
+				E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */,
 				9DA555D52241FC6600EC8CC3 /* ValueAccessible.swift in Sources */,
 				9D2E269E2240D1CA00C9EDF7 /* Wrappers.swift in Sources */,
 			);
@@ -336,6 +343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED74A73A2243E0CC00D4E99C /* DependencyTests.swift in Sources */,
+				E9A6617E23839933007D4AEC /* AnyUnioStreamTests.swift in Sources */,
 				ED74A63D2243C2EE00D4E99C /* PrimitivePropertyTests.swift in Sources */,
 				ED74A73C2243E43D00D4E99C /* UnioStreamTests.swift in Sources */,
 				ED74A7382243D99D00D4E99C /* WrappersTests.swift in Sources */,

--- a/Unio/AnyUnioStream.swift
+++ b/Unio/AnyUnioStream.swift
@@ -1,0 +1,22 @@
+//
+//  AnyUnioStream.swift
+//  UnioTests
+//
+//  Created by Akio Yasui on 2019/11/19.
+//  Copyright © 2019 tv.abema. All rights reserved.
+//
+
+/// A type-erased wrapper for any UnioStreamType.
+public final class AnyUnioStream<Input: InputType, Output: OutputType>: UnioStreamType {
+    public let input: InputWrapper<Input>
+    public let output: OutputWrapper<Output>
+
+    /// Strong reference to the actual stream for preventing it being released.
+    private let _stream: AnyObject
+
+    public init<Stream: UnioStreamType>(_ stream: Stream) where Stream.Input == Input, Stream.Output == Output {
+        self._stream = stream
+        self.input = stream.input
+        self.output = stream.output
+    }
+}

--- a/Unio/UnioStream.swift
+++ b/Unio/UnioStream.swift
@@ -8,6 +8,14 @@
 
 import RxSwift
 
+/// A type which have unidirectional input and output.
+public protocol UnioStreamType: AnyObject {
+    associatedtype Input: InputType
+    associatedtype Output: OutputType
+    var input: InputWrapper<Input> { get }
+    var output: OutputWrapper<Output> { get }
+}
+
 /// Makes possible to implement Unidirectional input / output stream and be able to implement LogicType to  its self.
 ///
 /// ```
@@ -26,7 +34,7 @@ import RxSwift
 ///     }
 /// }
 /// ```
-public typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType
+public typealias UnioStream<Logic: LogicType> = PrimitiveStream<Logic> & LogicType & UnioStreamType
 
 /// Makes possible to implement Unidirectional input / output stream.
 open class PrimitiveStream<Logic: LogicType> {

--- a/UnioTests/TestCases/AnyUnioStreamTests.swift
+++ b/UnioTests/TestCases/AnyUnioStreamTests.swift
@@ -1,0 +1,118 @@
+//
+//  AnyUnioStreamTests.swift
+//  UnioTests
+//
+//  Created by Akio Yasui on 2019/11/19.
+//  Copyright © 2019 tv.abema. All rights reserved.
+//
+
+import RxRelay
+import RxSwift
+import XCTest
+import Unio
+
+final class AnyUnioStreamTests: XCTestCase {
+    func testAnyUnioStreamTests() {
+        do {
+            let stack = BehaviorRelay<Int?>(value: nil)
+
+            let stream = AdderStream<Int>()
+            let anyStream = AnyUnioStream(stream)
+
+            let disposable = anyStream.output.result.bind(to: stack)
+            defer { disposable.dispose() }
+
+            anyStream.input.lhs(1)
+            anyStream.input.rhs(2)
+
+            XCTAssertEqual(stack.value, 1 + 2)
+        }
+
+        do {
+            let stack = BehaviorRelay<Int?>(value: nil)
+
+            let mockStream = MockAdderStream<Int>()
+            let anyStream = AnyUnioStream(mockStream)
+
+            let disposable = anyStream.output.result.bind(to: stack)
+            defer { disposable.dispose() }
+
+            anyStream.input.lhs(1)
+            anyStream.input.rhs(2)
+
+            XCTAssertEqual(stack.value, nil)
+
+            mockStream._result.accept(123)
+
+            XCTAssertEqual(stack.value, 123)
+        }
+    }
+
+    func test_actual_stream_is_not_released_until_wrapper_is_released() {
+        var stream = Optional.some(AdderStream<Int>())
+        var anyStream = Optional.some(AnyUnioStream(stream!))
+        _ = anyStream // suppress "never read" warning
+
+        var isDeinitCalled = false
+        stream!._deinitHandler = { isDeinitCalled = true }
+
+        stream = nil
+        XCTAssertEqual(isDeinitCalled, false)
+
+        anyStream = nil
+        XCTAssertEqual(isDeinitCalled, true)
+    }
+}
+
+protocol AdderStreamType: UnioStreamType {
+    associatedtype T: AdditiveArithmetic
+    var input: InputWrapper<AdderStream<T>.Input> { get }
+    var output: OutputWrapper<AdderStream<T>.Output> { get }
+}
+
+final class AdderStream<T: AdditiveArithmetic>: UnioStream<AdderStream>, AdderStreamType {
+    var _deinitHandler: (() -> Void)?
+
+    struct Input: InputType {
+        let lhs = PublishRelay<T>()
+        let rhs = PublishRelay<T>()
+    }
+
+    struct Output: OutputType {
+        let result: PublishRelay<T>
+    }
+
+    init() {
+        super.init(input: Input(),
+                   state: State(),
+                   extra: Extra())
+    }
+
+    deinit {
+        _deinitHandler?()
+    }
+
+    static func bind(from dependency: Dependency<Input, NoState, NoExtra>, disposeBag: DisposeBag) -> Output {
+        let result = PublishRelay<T>()
+        Observable
+            .combineLatest(dependency.inputObservables.lhs,
+                           dependency.inputObservables.rhs,
+                           resultSelector: +)
+            .bind(to: result)
+            .disposed(by: disposeBag)
+        return Output(result: result)
+    }
+}
+
+final class MockAdderStream<T: AdditiveArithmetic>: AdderStreamType {
+    let input: InputWrapper<AdderStream<T>.Input>
+    let output: OutputWrapper<AdderStream<T>.Output>
+
+    let _input = AdderStream<T>.Input()
+    let _result = PublishRelay<T>()
+
+    init() {
+        input = InputWrapper(_input)
+        output = OutputWrapper(AdderStream<T>.Output(result: _result))
+    }
+}


### PR DESCRIPTION
This PR introduces `UnioStreamType`, which defines a type with specific `Input` and `Output`, and `AnyUnioStream` as a type-erased wrapper of `UnioStreamType`.

These changes can be considered purely additive, not breaking.

# Background

You can define a generic UnioStream.
The example below defines `AdderStream`, which works with arbitrary types conform to `AdditiveArithmetic`:

```swift
protocol AdderStreamType: AnyObject {
    associatedtype T: AdditiveArithmetic
    var input: InputWrapper<AdderStream<T>.Input> { get }
    var output: OutputWrapper<AdderStream<T>.Output> { get }
}

final class AdderStream<T: AdditiveArithmetic>: UnioStream<AdderStream>, AdderStreamType {
    struct Input: InputType {
        let lhs = PublishRelay<T>()
        let rhs = PublishRelay<T>()
    }

    struct Output: OutputType {
        let result: PublishRelay<T>
    }

    static func bind(from dependency: Dependency<Input, NoState, NoExtra>, disposeBag: DisposeBag) -> Output {
        let result = PublishRelay<T>()
        Observable
            .combineLatest(dependency.inputObservables.lhs,
                           dependency.inputObservables.rhs,
                           resultSelector: +)
            .bind(to: result)
            .disposed(by: disposeBag)
        return Output(result: result)
    }
}
```

The problem here is that you cannot use `AdderStreamType` as an existential, since it is a PAT (Protocol with Associated Types.) Not being able to do this prevents, for example, constructor injection:

```swift
init(stream: AdderStreamType) { // <!> Protocol 'AdderStreamType' can only be used as a generic constraint 
```

# Solution

This PR introduces `UnioStreamType`, which defines a type with specific `Input` and `Output`, and `AnyUnioStream` for a type-erased wrapper of `UnioStreamType`.
These types allows you to define parameters or variables accepting any type which have specific `Input` and `Output`.

```swift
struct Calc {
    init(stream: AnyUnioStream<AdderStream<Int>.Input, AdderStream<Int>.Output>) { ... }
}
```

or more legibly with `typealias`:

```swift
struct Calc {
    typealias AnyFooStream<T: AdditiveArithmetic> = AnyUnioStream<AdderStream<T>.Input, AdderStream<T>.Output>

    init(stream: AnyFooStream<Int>) { ... }
}
```

You need to have a little modification to wrap it with `AnyUnioStream` in the call site.
```swift
Calc(.init(AdderStream())
```

This PR adds a requirement to `typealias UnioStream` to be `UnioStreamType`, but you need no additional work as any `PrimitiveStream` can automatically conform to the protocol.
You need explicitly mark `protocol ___StreamType` to conform `UnioStreamType` as below, but it's not a requirement unless you need to wrap it with `AnyUnioStream`.

```swift
protocol AdderStreamType: UnioStreamType {
     associatedtype T: AdditiveArithmetic
     var input: InputWrapper<AdderStream<T>.Input> { get }
     var output: OutputWrapper<AdderStream<T>.Output> { get }
 }
```