### PR TITLE
Add Computed

### DIFF
--- a/Unio.xcodeproj/project.pbxproj
+++ b/Unio.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		9DA555CB2241DE8400EC8CC3 /* BehaviorSubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555CA2241DE8400EC8CC3 /* BehaviorSubjectType.swift */; };
 		9DA555D32241FC0400EC8CC3 /* AcceptableRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */; };
 		9DA555D52241FC6600EC8CC3 /* ValueAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */; };
+		9DF9334B23FD1091003C564C /* Computed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF9334A23FD1091003C564C /* Computed.swift */; };
 		E9A6617E23839933007D4AEC /* AnyUnioStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */; };
 		E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6618123839952007D4AEC /* AnyUnioStream.swift */; };
 		ED4D482A23DC1B01004868D9 /* AnyLogicBasedStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4D482923DC1B01004868D9 /* AnyLogicBasedStream.swift */; };
@@ -88,6 +89,7 @@
 		9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptableRelay.swift; sourceTree = "<group>"; };
 		9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueAccessible.swift; sourceTree = "<group>"; };
 		9DA5623F2362DB760048F2B9 /* Unio.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Unio.xcconfig; sourceTree = "<group>"; };
+		9DF9334A23FD1091003C564C /* Computed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Computed.swift; sourceTree = "<group>"; };
 		E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStreamTests.swift; sourceTree = "<group>"; };
 		E9A6618123839952007D4AEC /* AnyUnioStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStream.swift; sourceTree = "<group>"; };
 		ED4D482923DC1B01004868D9 /* AnyLogicBasedStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyLogicBasedStream.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				9DA555C92241DE5F00EC8CC3 /* RxTypes */,
 				ED4D482923DC1B01004868D9 /* AnyLogicBasedStream.swift */,
 				E9A6618123839952007D4AEC /* AnyUnioStream.swift */,
+				9DF9334A23FD1091003C564C /* Computed.swift */,
 				9D2E269C2240D1CA00C9EDF7 /* Dependency.swift */,
 				9D2E26972240D1CA00C9EDF7 /* ExtraType.swift */,
 				9D2E267D2240D18500C9EDF7 /* Info.plist */,
@@ -330,11 +333,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				9DA555D32241FC0400EC8CC3 /* AcceptableRelay.swift in Sources */,
+				ED4D482A23DC1B01004868D9 /* AnyLogicBasedStream.swift in Sources */,
+				E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */,
 				9D2E26A32240D1CA00C9EDF7 /* BehaviorRelayType.swift in Sources */,
 				9DA555CB2241DE8400EC8CC3 /* BehaviorSubjectType.swift in Sources */,
+				9DF9334B23FD1091003C564C /* Computed.swift in Sources */,
 				9D2E26A62240D1CA00C9EDF7 /* Dependency.swift in Sources */,
 				9D2E26A12240D1CA00C9EDF7 /* ExtraType.swift in Sources */,
-				ED4D482A23DC1B01004868D9 /* AnyLogicBasedStream.swift in Sources */,
 				9D2E26A22240D1CA00C9EDF7 /* InputType.swift in Sources */,
 				9D2E269F2240D1CA00C9EDF7 /* LogicType.swift in Sources */,
 				9D2E26A52240D1CA00C9EDF7 /* OutputType.swift in Sources */,
@@ -342,7 +347,6 @@
 				9D2E269D2240D1CA00C9EDF7 /* PublishRelayType.swift in Sources */,
 				9D2E26A02240D1CA00C9EDF7 /* StateType.swift in Sources */,
 				9D2E26A42240D1CA00C9EDF7 /* UnioStream.swift in Sources */,
-				E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */,
 				9DA555D52241FC6600EC8CC3 /* ValueAccessible.swift in Sources */,
 				9D2E269E2240D1CA00C9EDF7 /* Wrappers.swift in Sources */,
 			);
@@ -352,11 +356,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED82DE2C23DC2FF9003B6855 /* SR12081Tests.swift in Sources */,
-				ED4D482C23DC2BC2004868D9 /* SR12081Check.Streams.swift in Sources */,
-				ED74A73A2243E0CC00D4E99C /* DependencyTests.swift in Sources */,
 				E9A6617E23839933007D4AEC /* AnyUnioStreamTests.swift in Sources */,
+				ED74A73A2243E0CC00D4E99C /* DependencyTests.swift in Sources */,
 				ED74A63D2243C2EE00D4E99C /* PrimitivePropertyTests.swift in Sources */,
+				ED4D482C23DC2BC2004868D9 /* SR12081Check.Streams.swift in Sources */,
+				ED82DE2C23DC2FF9003B6855 /* SR12081Tests.swift in Sources */,
 				ED74A73C2243E43D00D4E99C /* UnioStreamTests.swift in Sources */,
 				ED74A7382243D99D00D4E99C /* WrappersTests.swift in Sources */,
 			);

--- a/Unio/Computed.swift
+++ b/Unio/Computed.swift
@@ -11,11 +11,13 @@ import Foundation
 /// Represents computed property
 public final class Computed<Element> {
 
+    @inlinable
     public var value: Element {
         return getter()
     }
 
-    private let getter: () -> Element
+    @usableFromInline
+    let getter: () -> Element
 
     public init(getter: @escaping () -> Element) {
         self.getter = getter

--- a/Unio/Computed.swift
+++ b/Unio/Computed.swift
@@ -1,0 +1,31 @@
+//
+//  Computed.swift
+//  Unio
+//
+//  Created by marty-suzuki on 2020/2/19.
+//  Copyright © 2020 tv.abema. All rights reserved.
+//
+
+import Foundation
+
+/// Represents computed property
+public final class Computed<Element> {
+
+    public var value: Element {
+        return getter()
+    }
+
+    private let getter: () -> Element
+
+    public init(getter: @escaping () -> Element) {
+        self.getter = getter
+    }
+
+    public init(capture element: Element) {
+        self.getter = { [element] in element }
+    }
+
+    public init(_ computed: Computed<Element>) {
+        self.getter = computed.getter
+    }
+}

--- a/Unio/Wrappers.swift
+++ b/Unio/Wrappers.swift
@@ -151,6 +151,11 @@ public final class OutputWrapper<T: OutputType> {
 
         return _dependency[keyPath: keyPath]
     }
+
+    public subscript<E>(dynamicMember keyPath: KeyPath<T, Computed<E>>) -> E {
+
+        return _dependency[keyPath: keyPath].value
+    }
 }
 
 /// Makes possible to access Observable that contained by T even while hides actual properties (BehaviorRelay, BehaviorSubject and so on).

--- a/UnioTests/TestCases/WrappersTests.swift
+++ b/UnioTests/TestCases/WrappersTests.swift
@@ -196,6 +196,19 @@ final class WrappersTests: XCTestCase {
         XCTAssertEqual(try testTarget.value(for: \.subject), expected)
         #endif
     }
+
+    func testOutput_computed() {
+
+        let expected = Int(arc4random())
+        dependency.outputComputed.accept(expected)
+        let testTarget = dependency.testTargetOutput
+
+        #if swift(>=5.1)
+        XCTAssertEqual(testTarget.computed, expected)
+        #else
+        XCTAssertEqual(testTarget[dynamicMember: \.computed], expected)
+        #endif
+    }
 }
 
 extension WrappersTests {
@@ -204,6 +217,7 @@ extension WrappersTests {
         let subject: BehaviorSubject<String?>
         let relay: BehaviorRelay<String?>
         let _observable: Observable<String>
+        let computed: Computed<Int?>
     }
 
     private struct Input: InputType {
@@ -221,6 +235,7 @@ extension WrappersTests {
 
         let outputSubject = BehaviorSubject<String?>(value: nil)
         let outputRelay = BehaviorRelay<String?>(value: nil)
+        let outputComputed: BehaviorRelay<Int?>
 
         let acceptForObservable: (String) -> Void
 
@@ -231,9 +246,13 @@ extension WrappersTests {
             let input = Input(relay: inputRelay, subject: inputSubject)
             self.testTargetInput = InputWrapper(input)
 
+            let computed = BehaviorRelay<Int?>(value: nil)
+            self.outputComputed = computed
+
             let output = Output(subject: outputSubject,
                                 relay: outputRelay,
-                                _observable: relayForObservable.asObservable())
+                                _observable: relayForObservable.asObservable(),
+                                computed: .init(getter: { computed.value }))
             self.testTargetOutput = OutputWrapper(output)
         }
     }


### PR DESCRIPTION
We sometimes want to access value without via Observable.
`Computed` supports above cases.

### Computed value case

```swift
let isHidden = BehaviorRelay<Bool>(value: false)

sturct Output: OutputType {
    let isHidden: Computed<Bool>
}

let output = OutputWrapper(Output(tabs: .init({ isHidden.value }))
output.isHidden // false

isHidden.accept(true)

output.isHidden // true
```

### Constant value case

```swift
enum Tab {
    case home
    case notification
    case mypage
}

sturct Output: OutputType {
    let tabs: Computed<[Tab]>
}

let output = OutputWrapper(Output(tabs: .init(caputure: [.home, .notification, .mypage])))
output.tabs // Be able to access `[Tab]`
```