### PR TITLE
Change to use xcframework

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "6.0.0"
+github "ReactiveX/RxSwift" "6.5.0"

--- a/Example/UnioSample.xcodeproj/project.pbxproj
+++ b/Example/UnioSample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,9 +11,9 @@
 		9D2E26CE2240D8EA00C9EDF7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9D2E26CD2240D8EA00C9EDF7 /* Assets.xcassets */; };
 		9D2E26D12240D8EA00C9EDF7 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9D2E26CF2240D8EA00C9EDF7 /* LaunchScreen.storyboard */; };
 		9D2E26EE2240D96000C9EDF7 /* Unio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26ED2240D96000C9EDF7 /* Unio.framework */; };
-		9D2E26F12240D98300C9EDF7 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26EF2240D98300C9EDF7 /* RxSwift.framework */; };
-		9D9EEC0F22816B1700DF5D97 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D9EEC0E22816B1700DF5D97 /* RxRelay.framework */; };
-		9D9EEC1022816B8700DF5D97 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26F02240D98300C9EDF7 /* RxCocoa.framework */; };
+		C51136B027B38B8800E8F26C /* RxCocoa.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C51136AF27B38B8800E8F26C /* RxCocoa.xcframework */; };
+		C51136B427B38CDC00E8F26C /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C51136AC27B38B7400E8F26C /* RxRelay.xcframework */; };
+		C51136B627B38CE500E8F26C /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C51136A527B38B1100E8F26C /* RxSwift.xcframework */; };
 		EDE43F2D22428D1000B157F9 /* GitHubSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE43F2B22428D1000B157F9 /* GitHubSearchViewController.swift */; };
 		EDE43F2E22428D1000B157F9 /* GitHubSearchViewStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE43F2C22428D1000B157F9 /* GitHubSearchViewStream.swift */; };
 		EDE43F3022428EE100B157F9 /* GitHubSearchLogicStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE43F2F22428EE100B157F9 /* GitHubSearchLogicStream.swift */; };
@@ -45,6 +45,9 @@
 		9D2E26EF2240D98300C9EDF7 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = ../Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		9D2E26F02240D98300C9EDF7 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = ../Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		9D9EEC0E22816B1700DF5D97 /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = ../Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
+		C51136A527B38B1100E8F26C /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = ../Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
+		C51136AC27B38B7400E8F26C /* RxRelay.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxRelay.xcframework; path = ../Carthage/Build/RxRelay.xcframework; sourceTree = "<group>"; };
+		C51136AF27B38B8800E8F26C /* RxCocoa.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxCocoa.xcframework; path = ../Carthage/Build/RxCocoa.xcframework; sourceTree = "<group>"; };
 		EDE43F2B22428D1000B157F9 /* GitHubSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchViewController.swift; sourceTree = "<group>"; };
 		EDE43F2C22428D1000B157F9 /* GitHubSearchViewStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchViewStream.swift; sourceTree = "<group>"; };
 		EDE43F2F22428EE100B157F9 /* GitHubSearchLogicStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchLogicStream.swift; sourceTree = "<group>"; };
@@ -59,9 +62,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D9EEC1022816B8700DF5D97 /* RxCocoa.framework in Frameworks */,
-				9D9EEC0F22816B1700DF5D97 /* RxRelay.framework in Frameworks */,
-				9D2E26F12240D98300C9EDF7 /* RxSwift.framework in Frameworks */,
+				C51136B027B38B8800E8F26C /* RxCocoa.xcframework in Frameworks */,
+				C51136B627B38CE500E8F26C /* RxSwift.xcframework in Frameworks */,
+				C51136B427B38CDC00E8F26C /* RxRelay.xcframework in Frameworks */,
 				9D2E26EE2240D96000C9EDF7 /* Unio.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -124,6 +127,9 @@
 		9D2E26EC2240D96000C9EDF7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C51136AF27B38B8800E8F26C /* RxCocoa.xcframework */,
+				C51136AC27B38B7400E8F26C /* RxRelay.xcframework */,
+				C51136A527B38B1100E8F26C /* RxSwift.xcframework */,
 				9D9EEC0E22816B1700DF5D97 /* RxRelay.framework */,
 				9D2E26F02240D98300C9EDF7 /* RxCocoa.framework */,
 				9D2E26EF2240D98300C9EDF7 /* RxSwift.framework */,
@@ -142,7 +148,6 @@
 				9D2E26BF2240D8E800C9EDF7 /* Sources */,
 				9D2E26C02240D8E800C9EDF7 /* Frameworks */,
 				9D2E26C12240D8E800C9EDF7 /* Resources */,
-				9D2E26F32240D99400C9EDF7 /* carthage copy-frameworks */,
 			);
 			buildRules = (
 			);
@@ -229,30 +234,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		9D2E26F32240D99400C9EDF7 /* carthage copy-frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/../Carthage/Build/iOS/RxCocoa.framework",
-				"$(SRCROOT)/../Carthage/Build/iOS/RxSwift.framework",
-				"$(SRCROOT)/../Carthage/Build/iOS/RxRelay.framework",
-			);
-			name = "carthage copy-frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		9D2E26BF2240D8E800C9EDF7 /* Sources */ = {

--- a/Example/UnioSample.xcodeproj/project.pbxproj
+++ b/Example/UnioSample.xcodeproj/project.pbxproj
@@ -42,9 +42,6 @@
 		9D2E26D72240D8EA00C9EDF7 /* UnioSampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnioSampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D2E26DD2240D8EA00C9EDF7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9D2E26ED2240D96000C9EDF7 /* Unio.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Unio.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9D2E26EF2240D98300C9EDF7 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = ../Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		9D2E26F02240D98300C9EDF7 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = ../Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
-		9D9EEC0E22816B1700DF5D97 /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = ../Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
 		C51136A527B38B1100E8F26C /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = ../Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		C51136AC27B38B7400E8F26C /* RxRelay.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxRelay.xcframework; path = ../Carthage/Build/RxRelay.xcframework; sourceTree = "<group>"; };
 		C51136AF27B38B8800E8F26C /* RxCocoa.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxCocoa.xcframework; path = ../Carthage/Build/RxCocoa.xcframework; sourceTree = "<group>"; };
@@ -130,9 +127,6 @@
 				C51136AF27B38B8800E8F26C /* RxCocoa.xcframework */,
 				C51136AC27B38B7400E8F26C /* RxRelay.xcframework */,
 				C51136A527B38B1100E8F26C /* RxSwift.xcframework */,
-				9D9EEC0E22816B1700DF5D97 /* RxRelay.framework */,
-				9D2E26F02240D98300C9EDF7 /* RxCocoa.framework */,
-				9D2E26EF2240D98300C9EDF7 /* RxSwift.framework */,
 				9D2E26ED2240D96000C9EDF7 /* Unio.framework */,
 			);
 			name = Frameworks;

--- a/Unio.xcodeproj/project.pbxproj
+++ b/Unio.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,22 +19,22 @@
 		9D2E26A42240D1CA00C9EDF7 /* UnioStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E269A2240D1CA00C9EDF7 /* UnioStream.swift */; };
 		9D2E26A52240D1CA00C9EDF7 /* OutputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E269B2240D1CA00C9EDF7 /* OutputType.swift */; };
 		9D2E26A62240D1CA00C9EDF7 /* Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E269C2240D1CA00C9EDF7 /* Dependency.swift */; };
-		9D2E26AA2240D1F200C9EDF7 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */; };
-		9D9EEC0B228168F800DF5D97 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D9EEC0A228168F800DF5D97 /* RxRelay.framework */; };
-		9D9EEC0C2281699000DF5D97 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D9EEC0A228168F800DF5D97 /* RxRelay.framework */; };
-		9D9EEC0D2281699800DF5D97 /* RxRelay.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 9D9EEC0A228168F800DF5D97 /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9DA555CB2241DE8400EC8CC3 /* BehaviorSubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555CA2241DE8400EC8CC3 /* BehaviorSubjectType.swift */; };
 		9DA555D32241FC0400EC8CC3 /* AcceptableRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */; };
 		9DA555D52241FC6600EC8CC3 /* ValueAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */; };
 		9DF9334B23FD1091003C564C /* Computed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF9334A23FD1091003C564C /* Computed.swift */; };
+		C511369E27B3898700E8F26C /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C511369827B388B900E8F26C /* RxRelay.xcframework */; };
+		C51136A127B3898900E8F26C /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C511369927B388B900E8F26C /* RxSwift.xcframework */; };
+		C51136A327B38A0200E8F26C /* RxRelay.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C511369827B388B900E8F26C /* RxRelay.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C51136A427B38A0200E8F26C /* RxSwift.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C511369927B388B900E8F26C /* RxSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C51136B827B38D2700E8F26C /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C511369827B388B900E8F26C /* RxRelay.xcframework */; };
+		C51136B927B38D2B00E8F26C /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C511369927B388B900E8F26C /* RxSwift.xcframework */; };
 		E9A6617E23839933007D4AEC /* AnyUnioStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */; };
 		E9A6618223839952007D4AEC /* AnyUnioStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6618123839952007D4AEC /* AnyUnioStream.swift */; };
 		ED4D482A23DC1B01004868D9 /* AnyLogicBasedStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4D482923DC1B01004868D9 /* AnyLogicBasedStream.swift */; };
 		ED4D482C23DC2BC2004868D9 /* SR12081Check.Streams.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4D482B23DC2BC2004868D9 /* SR12081Check.Streams.swift */; };
 		ED6897C122B184EE00B04DA0 /* PrimitiveProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6897C022B184EE00B04DA0 /* PrimitiveProperty.swift */; };
 		ED74A63D2243C2EE00D4E99C /* PrimitivePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED74A63C2243C2EE00D4E99C /* PrimitivePropertyTests.swift */; };
-		ED74A6402243C3DB00D4E99C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */; };
-		ED74A6432243C43400D4E99C /* RxSwift.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED74A7382243D99D00D4E99C /* WrappersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED74A7372243D99D00D4E99C /* WrappersTests.swift */; };
 		ED74A73A2243E0CC00D4E99C /* DependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED74A7392243E0CC00D4E99C /* DependencyTests.swift */; };
 		ED74A73C2243E43D00D4E99C /* UnioStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED74A73B2243E43D00D4E99C /* UnioStreamTests.swift */; };
@@ -58,8 +58,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9D9EEC0D2281699800DF5D97 /* RxRelay.framework in Copy Frameworks */,
-				ED74A6432243C43400D4E99C /* RxSwift.framework in Copy Frameworks */,
+				C51136A327B38A0200E8F26C /* RxRelay.xcframework in Copy Frameworks */,
+				C51136A427B38A0200E8F26C /* RxSwift.xcframework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -82,14 +82,14 @@
 		9D2E269A2240D1CA00C9EDF7 /* UnioStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnioStream.swift; sourceTree = "<group>"; };
 		9D2E269B2240D1CA00C9EDF7 /* OutputType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutputType.swift; sourceTree = "<group>"; };
 		9D2E269C2240D1CA00C9EDF7 /* Dependency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dependency.swift; sourceTree = "<group>"; };
-		9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		9D62B5452362DE7C008F8793 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
-		9D9EEC0A228168F800DF5D97 /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
 		9DA555CA2241DE8400EC8CC3 /* BehaviorSubjectType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectType.swift; sourceTree = "<group>"; };
 		9DA555D22241FC0400EC8CC3 /* AcceptableRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptableRelay.swift; sourceTree = "<group>"; };
 		9DA555D42241FC6600EC8CC3 /* ValueAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueAccessible.swift; sourceTree = "<group>"; };
 		9DA5623F2362DB760048F2B9 /* Unio.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Unio.xcconfig; sourceTree = "<group>"; };
 		9DF9334A23FD1091003C564C /* Computed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Computed.swift; sourceTree = "<group>"; };
+		C511369827B388B900E8F26C /* RxRelay.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxRelay.xcframework; path = Carthage/Build/RxRelay.xcframework; sourceTree = "<group>"; };
+		C511369927B388B900E8F26C /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		E9A6617D23839933007D4AEC /* AnyUnioStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStreamTests.swift; sourceTree = "<group>"; };
 		E9A6618123839952007D4AEC /* AnyUnioStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnioStream.swift; sourceTree = "<group>"; };
 		ED4D482923DC1B01004868D9 /* AnyLogicBasedStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyLogicBasedStream.swift; sourceTree = "<group>"; };
@@ -107,8 +107,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D9EEC0B228168F800DF5D97 /* RxRelay.framework in Frameworks */,
-				9D2E26AA2240D1F200C9EDF7 /* RxSwift.framework in Frameworks */,
+				C511369E27B3898700E8F26C /* RxRelay.xcframework in Frameworks */,
+				C51136A127B3898900E8F26C /* RxSwift.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,8 +116,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D9EEC0C2281699000DF5D97 /* RxRelay.framework in Frameworks */,
-				ED74A6402243C3DB00D4E99C /* RxSwift.framework in Frameworks */,
+				C51136B927B38D2B00E8F26C /* RxSwift.xcframework in Frameworks */,
+				C51136B827B38D2700E8F26C /* RxRelay.xcframework in Frameworks */,
 				9D2E26832240D18500C9EDF7 /* Unio.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -180,8 +180,8 @@
 		9D2E26A72240D1F200C9EDF7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9D9EEC0A228168F800DF5D97 /* RxRelay.framework */,
-				9D2E26A82240D1F200C9EDF7 /* RxSwift.framework */,
+				C511369827B388B900E8F26C /* RxRelay.xcframework */,
+				C511369927B388B900E8F26C /* RxSwift.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";


### PR DESCRIPTION
Changed to use xcframework。
Carthage 0.37.0 supports xcframework and  M1 Mac with arm64-simulator architecture  is on the market.